### PR TITLE
Do replacements before fingerprinting assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,9 @@
     "ember-cli-babel": "^7.1.2"
   },
   "ember-addon": {
-    "configPath": "tests/dummy/config"
+    "configPath": "tests/dummy/config",
+    "before": [
+      "broccoli-asset-rev"
+    ]
   }
 }


### PR DESCRIPTION
When using broccoli-asset-rev (fingerprint), this plugin should do the stuff before the other addon replacements.

For example, having a variable `MY_ASSETS_PATH = '/assets/vendor'` and an `index.html` with a path like this:

```html
<meta property="og:image" content="@@MY_ASSETS_PATH/my-image.png" />
```

Should output a result like this:

```html
<meta property="og:image" content="/assets/vendor/my-image-c42df74ca2750dbcef042fc3a0637745.png" />
```

Instead of the current result:

```html
<meta property="og:image" content="/assets/vendor/my-image.png" />
```